### PR TITLE
docs: add Performance notes documenting SIMD behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The implementation is optimized for secure memory handling and integrates with [
 - [API reference](#api-reference)
   - [`ChaCha20`](#chacha20)
 - [Usage notes](#usage-notes)
+- [Performance notes](#performance-notes)
 - [Security notes](#security-notes)
 - [Validation and test vectors](#validation-and-test-vectors)
 - [Development](#development)
@@ -149,6 +150,15 @@ If you split messages across frames/chunks, ensure both sender and receiver agre
 - message boundaries
 - replay protections
 - encoding/canonicalization of higher-level payloads
+
+---
+
+## Performance notes
+
+- The `DoFinal(byte[] output, int offset)` path uses a SIMD-accelerated XOR routine when hardware vector support is available at runtime (`Vector.IsHardwareAccelerated`).
+- SIMD use is automatic and transparent; no extra configuration is required.
+- A scalar fallback is always used when SIMD is unavailable or for any trailing bytes that do not fill a full vector width.
+- The `DoFinal(PinnedMemory<byte> output, int offset)` overload currently uses scalar writes.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Clarify README to reflect that the implementation can use hardware SIMD acceleration for XOR operations and to note which public overloads are affected.

### Description

- Added a new `Performance notes` section to the README and updated the table of contents.
- Documented that `DoFinal(byte[] output, int offset)` uses SIMD acceleration when `Vector.IsHardwareAccelerated` is true and that SIMD is automatic with a scalar fallback for trailing/unsupported sizes.
- Noted that `DoFinal(PinnedMemory<byte> output, int offset)` currently uses scalar writes.